### PR TITLE
Fixes case for long-deprecated attr access on django > 1.6

### DIFF
--- a/webservices/sync.py
+++ b/webservices/sync.py
@@ -54,7 +54,7 @@ def provider_for_django(provider):
             django_key = 'HTTP_%s' % key.upper().replace('-', '_')
             return request.META.get(django_key, default)
         method = request.method
-        if getattr(request, 'body', None):
+        if hasattr(request, 'body'):
             signed_data = request.body
         else:
             signed_data = request.raw_post_data


### PR DESCRIPTION
 * Requests without a body invoke `request.raw_post_data`
   as opposed to `request.body`. (see https://github.com/aldryn/django-simple-sso/issues/32)